### PR TITLE
Straka/tests

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -9,15 +9,6 @@ pub use threshold_bls::{
     sig::Share,
 };
 
-pub trait PRFScheme: Scheme {
-    type Error: Error;
-
-    /// Evaluates the PRF on the given plaintext tag and message input.
-    ///
-    /// Will result in the same value as calling `blind_msg`, `blind_eval`, `unblind_resp` in sequence.
-    fn eval(private: &Self::Private, tag: &[u8], msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
-}
-
 pub trait POPRFScheme: Scheme {
     type Error: Error;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,10 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::error::Error;
 
 // Export polynomial library components used here so the caller may use them.
-pub use threshold_bls::{poly::{Poly, Idx, Eval}, sig::Share};
+pub use threshold_bls::{
+    poly::{Eval, Idx, Poly},
+    sig::Share,
+};
 
 pub trait PRFScheme: Scheme {
     type Error: Error;
@@ -51,11 +54,7 @@ pub trait POPRFScheme: Scheme {
         resp: &Self::BlindResp,
     ) -> Result<Vec<u8>, Self::Error>;
 
-    fn eval(
-        private: &Self::Private,
-        tag: &[u8],
-        msg: &[u8],
-    ) -> Result<Vec<u8>, Self::Error>;
+    fn eval(private: &Self::Private, tag: &[u8], msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
     /// Evaluates the POPRF over a message and tag with a share of the private key.
     fn partial_eval(

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,16 +19,8 @@ pub trait POPRFScheme: Scheme {
     /// The blinding factor which will be used to unblind and verify the message.
     type Token: Serialize + DeserializeOwned;
 
-    // TODO: Does not really need to be part of the public interface. Can it be removed?
-    /// Proof included as part of BlindMsg to show that the message was created correctly.
-    type Proof: Serialize + DeserializeOwned;
-
     /// The blinded message type which is created by the client.
     type BlindMsg: Serialize + DeserializeOwned;
-
-    // TODO: Does not really need to be part of the public interface. Can it be removed?
-    /// Unblinded and unhashed evaluation response.
-    type Resp: Serialize + DeserializeOwned;
 
     /// The blinded response type which results from an eval on a blinded message and plaintext tag.
     type BlindResp: Serialize + DeserializeOwned;
@@ -55,6 +47,12 @@ pub trait POPRFScheme: Scheme {
         token: &Self::Token,
         tag: &[u8],
         resp: &Self::BlindResp,
+    ) -> Result<Vec<u8>, Self::Error>;
+
+    fn eval(
+        private: &Self::Private,
+        tag: &[u8],
+        msg: &[u8],
     ) -> Result<Vec<u8>, Self::Error>;
 
     /// Evaluates the POPRF over a message and tag with a share of the private key.

--- a/src/ffi/wasm.rs
+++ b/src/ffi/wasm.rs
@@ -47,9 +47,10 @@ pub fn blind_msg(message: &[u8], seed: &[u8]) -> Result<BlindedMessage> {
     let mut rng = get_rng(&[message, seed]);
 
     // Blind the message with this randomness.
-    let (blinding_factor, blinded_message) = POPRF::blind_msg(message, &mut rng).map_err(|err| {
-        JsValue::from_str(&format!("could not deserialize blinded response {}", err))
-    })?;
+    let (blinding_factor, blinded_message) =
+        POPRF::blind_msg(message, &mut rng).map_err(|err| {
+            JsValue::from_str(&format!("could not deserialize blinded response {}", err))
+        })?;
 
     // return the message and the blinding_factor used for blinding.
     Ok(BlindedMessage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ mod hash_to_field;
 mod poprf;
 mod poprfscheme;
 mod prf;
-use bls_crypto::BLSError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -260,7 +260,9 @@ where
         let mut y_B = B.clone();
         y_B.mul(&c_inv);
         y_B.add(&C::pair(&h, &vdc));
-        assert_eq!(y_A, y_B);
+        if y_A != y_B {
+            return Err(POPRFError::VerifyError);
+        }
 
         Ok(y_A)
     }

--- a/src/poprfscheme.rs
+++ b/src/poprfscheme.rs
@@ -164,6 +164,7 @@ where
 mod tests {
     use threshold_bls::curve::bls12377::PairingCurve as bls377;
     use threshold_bls::curve::bls12377::{G1Curve, G2Curve};
+    use threshold_bls::group::Element;
     use crate::poprf::Scheme;
     use crate::poprfscheme::{Share, Poly};
     use crate::api::POPRFScheme;
@@ -175,6 +176,20 @@ mod tests {
     fn blind_and_unblind() {
         let mut rng = rand::thread_rng(); 
         let (private, public) = G2Scheme::keypair(&mut rng);
+        let msg = "Hello World!";
+        let tag = "Bob";
+        let (token, blindmsg) = G2Scheme::blind_msg(msg.as_bytes(), &mut rng).unwrap();
+        let blind_resp = G2Scheme::blind_eval(&private, tag.as_bytes(), &blindmsg).unwrap();
+        let result = G2Scheme::unblind_resp(&public, &token, &tag.as_bytes(), &blind_resp).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn blind_and_unblind_wrong_key() {
+        let mut rng = rand::thread_rng(); 
+        let (mut private, public) = G2Scheme::keypair(&mut rng);
+        let elem = <G2Scheme as Scheme>::Private::rand(&mut rng);
+        private.mul(&elem);
         let msg = "Hello World!";
         let tag = "Bob";
         let (token, blindmsg) = G2Scheme::blind_msg(msg.as_bytes(), &mut rng).unwrap();
@@ -200,22 +215,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn unblind_partial_wrong_key() {
-        let mut rng = rand::thread_rng();
-        let msg = "Hello World!";
-        let tag = "Bob";
-        let n = 3;
-        let t = 3;
-        let (private, public) = G2Scheme::keypair(&mut rng);
-        let (token, blindmsg) = G2Scheme::blind_msg(msg.as_bytes(), &mut rng).unwrap();
-        let partial_key = Share{ private: private, index: 1 }; 
-        let blind_partial_resp = G2Scheme::blind_partial_eval(&partial_key, tag.as_bytes(), &blindmsg).unwrap();
-        let public_poly = Poly::<<G2Scheme as Scheme>::Public>::new_from(t-1, &mut rng);
-        let result = G2Scheme::unblind_partial_resp(&public_poly, &token, tag.as_bytes(), &blind_partial_resp).unwrap();
-    }
-
-    #[test]
     fn unblind_partial() {
         let mut rng = rand::thread_rng();
         let msg = "Hello World!";
@@ -229,6 +228,22 @@ mod tests {
         let private_key = Share{ private: private.get(index), index: index }; 
         let blind_partial_resp = G2Scheme::blind_partial_eval(&private_key, tag.as_bytes(), &blindmsg).unwrap();
         let result = G2Scheme::unblind_partial_resp(&public, &token, tag.as_bytes(), &blind_partial_resp).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn unblind_partial_wrong_key() {
+        let mut rng = rand::thread_rng();
+        let msg = "Hello World!";
+        let tag = "Bob";
+        let n = 3;
+        let t = 3;
+        let (private, public) = G2Scheme::keypair(&mut rng);
+        let (token, blindmsg) = G2Scheme::blind_msg(msg.as_bytes(), &mut rng).unwrap();
+        let partial_key = Share{ private: private, index: 1 }; 
+        let blind_partial_resp = G2Scheme::blind_partial_eval(&partial_key, tag.as_bytes(), &blindmsg).unwrap();
+        let public_poly = Poly::<<G2Scheme as Scheme>::Public>::new_from(t-1, &mut rng);
+        let result = G2Scheme::unblind_partial_resp(&public_poly, &token, tag.as_bytes(), &blind_partial_resp).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
First draft of tests for `poprfscheme.rs`. Also adds non-blinding `eval` function to the `poprf` api, in addition to removing unneeded types. Fixes error handling in `finalize` in `poprf.rs`.