### PR TITLE
Refactor HashToField Trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poprf"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 description = "A threshold-computable partially-oblivous psuedo-random function"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Pith POPRF
 
 > :warning: Functionality in this repository has not undergone detailed security review. It should
-> be used with caution.
+> be used with caution. It may contain unknown vulnerabilities and based on results of further
+> review, it may be changed in backwards incompatible ways.
 
 This repository implements a threshold-computable partially-oblivious pseudo-random function (POPRF)
 with evaluations that are verifiable by the client.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Pith POPRF
 
+> :warning: Functionality in this repository has not undergone detailed security review. It should
+> be used with caution.
+
 This repository implements a threshold-computable partially-oblivious pseudo-random function (POPRF)
 with evaluations that are verifiable by the client.
 

--- a/src/hash_to_field.rs
+++ b/src/hash_to_field.rs
@@ -30,8 +30,7 @@ pub trait HashToField {
     fn hash_to_field(&self, domain: &[u8], message: &[u8]) -> Result<Self::Output, HashError>;
 }
 
-/// A try-and-increment method for hashing to G1 and G2. See page 521 in
-/// https://link.springer.com/content/pdf/10.1007/3-540-45682-1_30.pdf.
+/// A try-and-increment method for hashing to scalar field
 #[derive(Clone)]
 pub struct TryAndIncrement<'a, H, F> {
     hasher: &'a H,
@@ -44,7 +43,7 @@ where
     F: Scalar,
 {
     /// Instantiates a new Try-and-increment hasher with the provided hashing method
-    /// and curve parameters based on the type
+    /// and field parameters based on the type
     pub fn new(h: &'a H) -> Self {
         TryAndIncrement {
             hasher: h,

--- a/src/hash_to_field.rs
+++ b/src/hash_to_field.rs
@@ -34,7 +34,6 @@ pub trait HashToField {
 
 /// A try-and-increment method for hashing to G1 and G2. See page 521 in
 /// https://link.springer.com/content/pdf/10.1007/3-540-45682-1_30.pdf.
-// TODO: Make this work with any curve, not just bls377
 #[derive(Clone)]
 pub struct TryAndIncrement<'a, H, F> {
     hasher: &'a H,
@@ -108,11 +107,6 @@ mod tests {
     use crate::bls12_377::Scalar;
     use crate::hash_to_field::{HashToField, TryAndIncrement};
     use bls_crypto::hashers::DirectHasher;
-
-    const RNG_SEED: [u8; 16] = [
-        0x5d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc, 0x06,
-        0x54,
-    ];
 
     #[test]
     fn test_hash_to_field() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/hash_to_field.rs
+++ b/src/hash_to_field.rs
@@ -34,7 +34,7 @@ pub trait HashToField {
 
 /// A try-and-increment method for hashing to G1 and G2. See page 521 in
 /// https://link.springer.com/content/pdf/10.1007/3-540-45682-1_30.pdf.
-//TODO: Make this work with any curve, not just bls377
+// TODO: Make this work with any curve, not just bls377
 #[derive(Clone)]
 pub struct TryAndIncrement<'a, H, F> {
     hasher: &'a H,
@@ -105,6 +105,29 @@ fn hash_length(n: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use crate::hash_to_field::{HashToField, TryAndIncrement};
+    use bls_crypto::hashers::DirectHasher;
+    use rand::Rng;
+    use threshold_bls::group::Scalar;
+
+    const RNG_SEED: [u8; 16] = [
+        0x5d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc, 0x06,
+        0x54,
+    ];
+
     #[test]
-    fn test_hash_to_field() {}
+    fn test_hash_to_field() {
+        let mut rng = rand::thread_rng();
+        let expected_hash = (); //TODO
+
+        let msg_size: u8 = rng.gen();
+        let mut msg: Vec<u8> = vec![0; msg_size as usize];
+        for i in msg.iter_mut() {
+            *i = rng.gen();
+        }
+
+        let hasher = TryAndIncrement::<_, dyn Scalar>::new(&DirectHasher);
+        let hash = hasher.hash_to_field(&[], &msg).unwrap();
+        assert_eq!(expected_hash, hash)
+    }
 }

--- a/src/hash_to_field.rs
+++ b/src/hash_to_field.rs
@@ -110,20 +110,39 @@ mod tests {
 
     #[test]
     fn test_hash_to_field() -> Result<(), Box<dyn std::error::Error>> {
-        let expected_hash: Scalar = bincode::deserialize(&hex::decode(
-            "9a94a71f3bd2efcfca590a6c619164d7ddf5be648c7029e426c3ce30f4a63711",
-        )?)?;
-        println!(
-            "expected scalar: {}",
-            hex::encode(bincode::serialize(&expected_hash)?)
-        );
+        struct Case {
+            // 8-bytes personalization string.
+            domain: &'static [u8],
+            message: &'static [u8],
+            expected: &'static [u8],
+        }
 
-        let msg = b"Hash to field test message";
+        let cases = vec![
+            Case {
+                domain: b"H2FTEST1",
+                message: b"Hash to field test message",
+                expected: b"7a76c4b0e7af6d8db05a7f38f30f3aabba99fcc55cc62b8068a5eb3d81396d07",
+            },
+            Case {
+                domain: b"H2FTEST2",
+                message: b"Hash to field test message",
+                expected: b"6b5a6b198eb79c293db3bd95eb9ae59ca2da80e98e815d0462f6421eb81c4710",
+            },
+            Case {
+                domain: b"H2FTEST1",
+                message: b"Hash to field test alternative message",
+                expected: b"e848153119b3864d5853447b62f5358063f3c181ff2f035dd5ce8eb1708c3e02",
+            },
+        ];
 
-        let hasher = TryAndIncrement::<_, Scalar>::new(&DirectHasher);
-        let hash = hasher.hash_to_field(&[], msg).unwrap();
-        println!("scalar: {}", hex::encode(bincode::serialize(&hash)?));
-        assert_eq!(expected_hash, hash);
+        for case in cases.iter() {
+            let expected_hash: Scalar = bincode::deserialize(&hex::decode(case.expected)?)?;
+
+            let hasher = TryAndIncrement::<_, Scalar>::new(&DirectHasher);
+            let hash = hasher.hash_to_field(case.domain, case.message).unwrap();
+            println!("scalar: {}", hex::encode(bincode::serialize(&hash)?));
+            assert_eq!(expected_hash, hash);
+        }
         Ok(())
     }
 }

--- a/src/hash_to_field.rs
+++ b/src/hash_to_field.rs
@@ -27,7 +27,7 @@ pub enum HashError {
 }
 
 pub trait HashToField {
-    type Output;
+    type Output: Scalar<RHS = Self::Output>;
 
     fn hash_to_field(&self, domain: &[u8], message: &[u8]) -> Result<Self::Output, HashError>;
 }
@@ -105,10 +105,9 @@ fn hash_length(n: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use crate::bls12_377::Scalar;
     use crate::hash_to_field::{HashToField, TryAndIncrement};
     use bls_crypto::hashers::DirectHasher;
-    use rand::Rng;
-    use threshold_bls::group::Scalar;
 
     const RNG_SEED: [u8; 16] = [
         0x5d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc, 0x06,
@@ -116,18 +115,21 @@ mod tests {
     ];
 
     #[test]
-    fn test_hash_to_field() {
-        let mut rng = rand::thread_rng();
-        let expected_hash = (); //TODO
+    fn test_hash_to_field() -> Result<(), Box<dyn std::error::Error>> {
+        let expected_hash: Scalar = bincode::deserialize(&hex::decode(
+            "9a94a71f3bd2efcfca590a6c619164d7ddf5be648c7029e426c3ce30f4a63711",
+        )?)?;
+        println!(
+            "expected scalar: {}",
+            hex::encode(bincode::serialize(&expected_hash)?)
+        );
 
-        let msg_size: u8 = rng.gen();
-        let mut msg: Vec<u8> = vec![0; msg_size as usize];
-        for i in msg.iter_mut() {
-            *i = rng.gen();
-        }
+        let msg = b"Hash to field test message";
 
-        let hasher = TryAndIncrement::<_, dyn Scalar>::new(&DirectHasher);
-        let hash = hasher.hash_to_field(&[], &msg).unwrap();
-        assert_eq!(expected_hash, hash)
+        let hasher = TryAndIncrement::<_, Scalar>::new(&DirectHasher);
+        let hash = hasher.hash_to_field(&[], msg).unwrap();
+        println!("scalar: {}", hex::encode(bincode::serialize(&hash)?));
+        assert_eq!(expected_hash, hash);
+        Ok(())
     }
 }

--- a/src/hash_to_field.rs
+++ b/src/hash_to_field.rs
@@ -1,5 +1,3 @@
-// use ark_bls12_377;
-// use ark_ec::PairingEngine;
 use ark_std::{end_timer, start_timer};
 use bls_crypto::{BLSError, Hasher};
 use byteorder::WriteBytesExt;

--- a/src/hash_to_field.rs
+++ b/src/hash_to_field.rs
@@ -9,6 +9,8 @@ use log::trace;
 use thiserror::Error;
 use threshold_bls::group::{Element, Scalar};
 
+const NUM_TRIES: u8 = 255;
+
 #[derive(Debug, Error)]
 pub enum HashError {
     /// Hashing to field failed
@@ -24,23 +26,44 @@ pub enum HashError {
     HashingError(#[from] bls_crypto::BLSError),
 }
 
-//TODO: Make this work with any curve, not just bls377
 pub trait HashToField {
-    const NUM_TRIES: u8 = 255;
+    type Scalar;
 
-    type Scalar: Scalar<RHS = Self::Scalar>;
+    fn hash_to_field(&self, domain: &[u8], message: &[u8]) -> Result<Self::Scalar, HashError>;
+}
 
-    fn hash_to_field(
-        &self,
-        domain: &[u8],
-        message: &[u8],
-    ) -> Result<(Self::Scalar, usize), HashError> {
+/// A try-and-increment method for hashing to G1 and G2. See page 521 in
+/// https://link.springer.com/content/pdf/10.1007/3-540-45682-1_30.pdf.
+//TODO: Make this work with any curve, not just bls377
+#[derive(Clone)]
+pub struct TryAndIncrement<'a, H> {
+    hasher: &'a H,
+}
+
+impl<'a, H> TryAndIncrement<'a, H>
+where
+    H: Hasher<Error = HashError>,
+{
+    /// Instantiates a new Try-and-increment hasher with the provided hashing method
+    /// and curve parameters based on the type
+    pub fn new(h: &'a H) -> Self {
+        TryAndIncrement { hasher: h }
+    }
+}
+
+impl<'a, H> HashToField for TryAndIncrement<'a, H>
+where
+    H: Hasher<Error = HashError>,
+{
+    type Scalar = Box<dyn Scalar<RHS=Self::Scalar>>;
+
+    fn hash_to_field(&self, domain: &[u8], message: &[u8]) -> Result<Self::Scalar, HashError> {
         let num_bytes = Self::Scalar::zero().serialized_size();
         let hash_loop_time = start_timer!(|| "try_and_increment::hash_loop");
-        let hash_bytes = Self::hash_length(num_bytes);
+        let hash_bytes = hash_length(num_bytes);
 
         let mut counter = [0; 1];
-        for c in 0..Self::NUM_TRIES {
+        for c in 0..NUM_TRIES {
             (&mut counter[..]).write_u8(c as u8)?;
             let candidate_hash =
                 DirectHasher.hash(domain, &[&counter, message].concat(), hash_bytes)?;
@@ -55,16 +78,26 @@ pub trait HashToField {
                 );
                 end_timer!(hash_loop_time);
 
-                return Ok((scalar_field, c as usize));
+                return Ok(scalar_field);
             }
         }
 
         Err(HashError::HashToFieldError)
     }
+}
 
-    fn hash_length(n: usize) -> usize {
-        let bits = (n * 8) as f64 / 256.0;
-        let rounded_bits = bits.ceil() * 256.0;
-        rounded_bits as usize / 8
-    }
+/// Given `n` bytes, it returns the value rounded to the nearest multiple of 256 bits (in bytes)
+/// e.g. 1. given 48 = 384 bits, it will return 64 bytes (= 512 bits)
+///      2. given 96 = 768 bits, it will return 96 bytes (no rounding needed since 768 is already a
+///         multiple of 256)
+fn hash_length(n: usize) -> usize {
+    let bits = (n * 8) as f64 / 256.0;
+    let rounded_bits = bits.ceil() * 256.0;
+    rounded_bits as usize / 8
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_hash_to_field() {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ pub enum POPRFError {
     #[error("could not hash to curve")]
     HashingError,
 
+    #[error("could not hash to scalar field")]
+    HashError(#[from] crate::hash_to_field::HashError),
+
     #[error("could not serialize")]
     SerializationError(#[from] Box<bincode::ErrorKind>),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod api;
+
+// Note: This conditionally should be removed when/if C FFI is added.
+#[cfg(feature = "wasm")]
 pub mod ffi;
 
 mod hash_to_field;
@@ -38,7 +41,7 @@ pub enum POPRFError {
 /// BLS12-377 instantiations.
 pub mod bls12_377 {
     use threshold_bls::curve::bls12377::PairingCurve;
-    pub use threshold_bls::curve::bls12377::{G1Curve, G2Curve};
+    pub use threshold_bls::curve::bls12377::{Scalar, G1Curve, G2Curve};
 
     /// Public Keys and messages on G2, tags on G1.
     pub type G2Scheme = super::poprf::G2Scheme<PairingCurve>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub enum POPRFError {
 /// BLS12-377 instantiations.
 pub mod bls12_377 {
     use threshold_bls::curve::bls12377::PairingCurve;
-    pub use threshold_bls::curve::bls12377::{Scalar, G1Curve, G2Curve};
+    pub use threshold_bls::curve::bls12377::{G1Curve, G2Curve, Scalar};
 
     /// Public Keys and messages on G2, tags on G1.
     pub type G2Scheme = super::poprf::G2Scheme<PairingCurve>;

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -1,5 +1,6 @@
 //use ark_ec::hashing::field_hashers::DefaultFieldHasher;
 //use rand::prelude::*;
+use crate::hash_to_field::HashToField;
 use crate::POPRFError;
 use rand::RngCore;
 use serde::{de::DeserializeOwned, Serialize};
@@ -95,9 +96,8 @@ pub mod poprf {
             let b_ser = bincode::serialize(&b)?;
             let mut concatenate: Vec<u8> = [g2_ser, v_ser, a_ser, b_ser].concat();
 
-            // TODO: implement hash to scalar field
-            let z = Self::Private::new();
-            //z.map(&concatenate)?;
+            // let z = Self::Private::new();
+            let z = HashToField::hash_to_field(&[], &concatenate).unwrap();
 
             // s1 = v1 - y * z
             let mut s1 = v1;
@@ -133,7 +133,7 @@ pub mod poprf {
             let v_ser = bincode::serialize(&v)?;
             let a_ser = bincode::serialize(&a)?;
             let b_ser = bincode::serialize(&b)?;
-            let mut concatenate: Vec<u8> = [g2_ser, v_ser, a_ser, b_ser].concat();
+            let concatenate: Vec<u8> = [g2_ser, v_ser, a_ser, b_ser].concat();
 
             // TODO: implement hash to scalar field
             let h = Self::Private::new();

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -1,6 +1,6 @@
 //use ark_ec::hashing::field_hashers::DefaultFieldHasher;
 //use rand::prelude::*;
-use crate::hash_to_field::TryAndIncrement;
+use crate::hash_to_field::{HashToField, TryAndIncrement};
 use crate::POPRFError;
 use bls_crypto::hashers::DirectHasher;
 use rand::RngCore;
@@ -38,7 +38,6 @@ pub trait Scheme: Debug {
 }
 
 pub mod poprf {
-    use std::hash::Hasher;
     use super::*;
 
     pub trait POPRF: Scheme {
@@ -97,7 +96,7 @@ pub mod poprf {
             let v_ser = bincode::serialize(&v)?;
             let a_ser = bincode::serialize(&a)?;
             let b_ser = bincode::serialize(&b)?;
-            let mut concatenate: Vec<u8> = [g2_ser, v_ser, a_ser, b_ser].concat();
+            let concatenate: Vec<u8> = [g2_ser, v_ser, a_ser, b_ser].concat();
 
             let hasher = TryAndIncrement::new(&DirectHasher);
             let z = hasher.hash_to_field(&[], &concatenate)?;
@@ -138,7 +137,6 @@ pub mod poprf {
             let b_ser = bincode::serialize(&b)?;
             let concatenate: Vec<u8> = [g2_ser, v_ser, a_ser, b_ser].concat();
 
-            // TODO: implement hash to scalar field
             let hasher = TryAndIncrement::new(&DirectHasher);
             let h = hasher.hash_to_field(&[], &concatenate)?;
 

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -146,18 +146,21 @@ pub mod poprf {
             s2: &Self::Private,
         ) -> Result<bool, POPRFError> {
             // v = g2^s1 * a^s2 * b^z
-            let mut g2 = Self::Public::one();
-            g2.mul(&s1);
-            let mut as2 = a.clone();
-            as2.mul(&s2);
-            let mut bz = b.clone();
-            bz.mul(&z);
-            let mut v = g2.clone();
-            v.add(&as2);
-            v.add(&bz);
+            let v = {
+                let mut g2s1 = Self::Public::one();
+                g2s1.mul(&s1);
+                let mut as2 = a.clone();
+                as2.mul(&s2);
+                let mut bz = b.clone();
+                bz.mul(&z);
+                let mut v = g2s1;
+                v.add(&as2);
+                v.add(&bz);
+                v
+            };
 
             // Concatenate (g2 || v || a || b)
-            let g2_ser = bincode::serialize(&g2)?;
+            let g2_ser = bincode::serialize(&Self::Public::one())?;
             let v_ser = bincode::serialize(&v)?;
             let a_ser = bincode::serialize(&a)?;
             let b_ser = bincode::serialize(&b)?;

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -1,5 +1,3 @@
-//use ark_ec::hashing::field_hashers::DefaultFieldHasher;
-//use rand::prelude::*;
 use crate::hash_to_field::{HashToField, TryAndIncrement};
 use crate::POPRFError;
 use bls_crypto::hashers::DirectHasher;

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -10,6 +10,9 @@ use threshold_bls::{
     sig::Share,
 };
 
+/// 8-byte constant hashing domain for the proof of related query subprotocol.
+const NIZK_HASH_DOMAIN: &'static [u8] = b"PoRQH2FF";
+
 /// The `Scheme` trait contains the basic information of the groups over which the PRF operations
 /// takes places and a way to create a valid key pair.
 ///
@@ -113,7 +116,7 @@ pub mod poprf {
             let concatenate: Vec<u8> = [g2_ser, v_ser, a_ser, b_ser].concat();
 
             let hasher = TryAndIncrement::new(&DirectHasher);
-            let z = hasher.hash_to_field(&[], &concatenate)?;
+            let z = hasher.hash_to_field(NIZK_HASH_DOMAIN, &concatenate)?;
 
             // s1 = v1 - y * z
             let s1 = {
@@ -165,7 +168,7 @@ pub mod poprf {
             let concatenate: Vec<u8> = [g2_ser, v_ser, a_ser, b_ser].concat();
 
             let hasher = TryAndIncrement::new(&DirectHasher);
-            let h = hasher.hash_to_field(&[], &concatenate)?;
+            let h = hasher.hash_to_field(NIZK_HASH_DOMAIN, &concatenate)?;
 
             Ok(*z == h)
         }

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -75,10 +75,10 @@ pub mod poprf {
 
         // Prove(a, b, c/r, d)
         fn prove<R: RngCore>(
-            a: &mut Self::Public,
+            mut a: Self::Public,
             b: &Self::Public,
-            x: &mut Self::Private,
-            y: &mut Self::Private,
+            mut x: Self::Private,
+            mut y: Self::Private,
             rng: &mut R,
         ) -> Result<(Self::Private, Self::Private, Self::Private), POPRFError> {
             let v1 = Self::Private::rand(rng);
@@ -115,8 +115,8 @@ pub mod poprf {
         }
 
         fn verify(
-            a: &mut Self::Public,
-            b: &mut Self::Public,
+            mut a: Self::Public,
+            mut b: Self::Public,
             z: &Self::Private,
             s1: &Self::Private,
             s2: &Self::Private,

--- a/src/poprfscheme.rs
+++ b/src/poprfscheme.rs
@@ -32,10 +32,10 @@ where
         let r_inv = r.inverse().ok_or(Self::Error::NoInverse).unwrap();
         c_div_r.mul(&r_inv);
         let (z, s_1, s_2) = C::prove(
-            &mut a.clone(),
+            a.clone(),
             &b,
-            &mut c_div_r.clone(),
-            &mut d.clone(),
+            c_div_r.clone(),
+            d.clone(),
             rng,
         )
         .unwrap();
@@ -51,7 +51,7 @@ where
         msg: &Self::BlindMsg,
     ) -> Result<Self::BlindResp, Self::Error> {
         let (z, s_1, s_2, a, b) = msg;
-        C::verify(&mut a.clone(), &mut b.clone(), &z, &s_1, &s_2)?
+        C::verify(a.clone(), b.clone(), &z, &s_1, &s_2)?
             .then(|| ())
             .ok_or(POPRFError::VerifyError)?;
         let (A, B) = C::blind_ev(private, tag, a, b)?;

--- a/src/poprfscheme.rs
+++ b/src/poprfscheme.rs
@@ -31,14 +31,7 @@ where
         let mut c_div_r = c.clone();
         let r_inv = r.inverse().ok_or(Self::Error::NoInverse).unwrap();
         c_div_r.mul(&r_inv);
-        let (z, s_1, s_2) = C::prove(
-            a.clone(),
-            &b,
-            c_div_r.clone(),
-            d.clone(),
-            rng,
-        )
-        .unwrap();
+        let (z, s_1, s_2) = C::prove(a.clone(), &b, c_div_r.clone(), d.clone(), rng).unwrap();
         let token = (r, c, d);
         let blmsg = (z, s_1, s_2, a, b);
         Ok((token, blmsg))


### PR DESCRIPTION
Left `HashToField` trait with only method signature, and created `TryAndIncrement` struct with the detailed implementation.