### PR TITLE
Straka/input check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 web-sys = { version = "0.3.57", optional = true }
 
 # TODO: Once that branch is merged into `master`, change the targeted branch.
-threshold-bls = { git = "https://github.com/celo-org/celo-threshold-bls-rs", rev = "18139d7dadf67b59d75aeefe2ad0c171850c4a12" }
+threshold-bls = { git = "https://github.com/celo-org/celo-threshold-bls-rs", rev = "8e8e152e0bbff6d27c61b1fd61f9015ac93a0641" }
 thiserror = "1.0.15"
 
 [dev-dependencies]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,7 @@
 use rand_core::RngCore;
-use threshold_bls::group::PrimeOrder;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt::Debug};
+use threshold_bls::group::PrimeOrder;
 
 // Export polynomial library components used here so the caller may use them.
 pub use threshold_bls::{

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,5 @@
 use rand_core::RngCore;
+use threshold_bls::group::PrimeOrder;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt::Debug};
 
@@ -21,7 +22,7 @@ pub trait Scheme: Debug {
     /// represented.
     type Public: Point<RHS = Self::Private> + Serialize + DeserializeOwned;
     /// `Evaluation` represents the group over which the evaluations are reresented.
-    type Evaluation: Element<RHS = Self::Private> + Serialize + DeserializeOwned;
+    type Evaluation: Element<RHS = Self::Private> + PrimeOrder + Serialize + DeserializeOwned;
 
     // Returns a new fresh keypair usable by the scheme.
     fn keypair<R: RngCore>(rng: &mut R) -> (Self::Private, Self::Public) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ pub enum PoprfError {
     #[error("proof verification failed")]
     VerifyError,
 
+    #[error("element is in wrong subgroup")]
+    WrongSubgroupError,
+
     #[error("could not inverse")]
     NoInverse,
 }

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -7,7 +7,7 @@ use bls_crypto::hashers::DirectHasher;
 use rand::RngCore;
 use std::{fmt::Debug, marker::PhantomData};
 use threshold_bls::{
-    group::{Element, PrimeOrder, PairingCurve, Point, Scalar},
+    group::{Element, PairingCurve, Point, PrimeOrder, Scalar},
     poly::{Eval, Poly},
     sig::Share,
 };
@@ -165,7 +165,7 @@ pub trait Poprf: Scheme {
         shares: &[Share<Self::Evaluation>],
     ) -> Result<Self::Evaluation, PoprfError> {
         for share in shares {
-            if !share.private.in_correct_subgroup() { 
+            if !share.private.in_correct_subgroup() {
                 return Err(PoprfError::WrongSubgroupError);
             }
         }
@@ -203,9 +203,11 @@ pub struct G2Scheme<C: PairingCurve> {
     m: PhantomData<C>,
 }
 
-impl<C: PairingCurve> Scheme for G2Scheme<C> 
+// GT Needs to implement PrimeOrder because the underlying arkworks
+// trait does not enforce being in the correct prime order subgroup
+impl<C: PairingCurve> Scheme for G2Scheme<C>
 where
-    C::GT : PrimeOrder
+    C::GT: PrimeOrder,
 {
     type Private = C::Scalar;
     type Public = C::G2;
@@ -259,7 +261,7 @@ where
         d: &Self::Private,
     ) -> Result<Self::Evaluation, PoprfError> {
         if !A.in_correct_subgroup() || !B.in_correct_subgroup() {
-            return Err(PoprfError::WrongSubgroupError)
+            return Err(PoprfError::WrongSubgroupError);
         }
         // y_A = A^(r^(-1))
         let y_A = {

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -164,6 +164,11 @@ pub trait Poprf: Scheme {
         threshold: usize,
         shares: &[Share<Self::Evaluation>],
     ) -> Result<Self::Evaluation, PoprfError> {
+        for share in shares {
+            if !share.private.in_correct_subgroup() { 
+                return Err(PoprfError::WrongSubgroupError);
+            }
+        }
         if threshold > shares.len() {
             return Err(PoprfError::NotEnoughResponses(shares.len(), threshold));
         }


### PR DESCRIPTION
This PR adds input sanitization for GT elements in `aggregate` and `finalize`, as the underlying arkworks trait `Field` does not enforce being the in correct prime order subgroup. 