### PR TITLE
Initial implementation of fuzzing starts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 getrandom = { version = "0.2", default-features = false, optional = true }
 rand_chacha = { version = "0.3.1", default-features = false, optional = true }
 wasm-bindgen = { version = "0.2.60", optional = true }
+arbitrary = { version = "1", optional=true, features = ["derive"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -45,6 +46,7 @@ thiserror = "1.0.15"
 
 [dev-dependencies]
 rand_chacha = { version = "0.3.1", default-features = false }
+arbitrary = { version = "1", features = ["derive"] }
 
 [features]
 # Build WASM bindings for use in JS environments
@@ -56,3 +58,6 @@ wasm-debug = ["wasm", "console_error_panic_hook", "web-sys/console"]
 
 # Enable parallel computation in arkworks code. Cannot be used with WASM.
 parallel = ["ark-ec/parallel", "ark-ff/parallel", "bls-crypto/parallel", "threshold-bls/parallel"]
+
+# Build fuzzing-specific components
+fuzzer = ["arbitrary/derive", "rand_chacha"]

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ arbitrary = { version = "1", features = ["derive"] }
 
 [dependencies.poprf]
 path = ".."
-features = ["fuzzer"]
+features = ["fuzzer", "wasm"]
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -36,5 +36,11 @@ doc = false
 [[bin]]
 name = "partialunblind"
 path = "fuzz_targets/partialunblind.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "wasm_unblind_resp"
+path = "fuzz_targets/wasm_unblind_resp.rs"
 test = false
 doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "poprf-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+rand_chacha = { version = "0.3.1", default-features = false }
+arbitrary = { version = "1", features = ["derive"] }
+
+[dependencies.poprf]
+path = ".."
+features = ["fuzzer"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "hashtofield"
+path = "fuzz_targets/hashtofield.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "poprfscheme"
+path = "fuzz_targets/poprfscheme.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "partialunblind"
+path = "fuzz_targets/partialunblind.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/hashtofield.rs
+++ b/fuzz/fuzz_targets/hashtofield.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use poprf::fuzz::hash_to_field;
+
+fuzz_target!(|data: &[u8]| {
+    hash_to_field(data);
+});

--- a/fuzz/fuzz_targets/partialunblind.rs
+++ b/fuzz/fuzz_targets/partialunblind.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use poprf::fuzz::{PartialUnblindFuzzInput, partialunblind};
+
+fuzz_target!(|data: PartialUnblindFuzzInput| {
+    partialunblind(data);
+});
+

--- a/fuzz/fuzz_targets/poprfscheme.rs
+++ b/fuzz/fuzz_targets/poprfscheme.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use poprf::fuzz::{PoprfFuzzInput, poprfscheme};
+
+fuzz_target!(|data: PoprfFuzzInput| {
+    poprfscheme(data);
+});
+

--- a/fuzz/fuzz_targets/wasm_unblind_resp.rs
+++ b/fuzz/fuzz_targets/wasm_unblind_resp.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use poprf::ffi::fuzz::{UnblindRespInput, unblind_resp};
+
+fuzz_target!(|data: UnblindRespInput| {
+    unblind_resp(data);
+});

--- a/src/ffi/fuzz.rs
+++ b/src/ffi/fuzz.rs
@@ -1,0 +1,23 @@
+use crate::ffi::wasm;
+
+static STATIC_TAG: &[u8] = b"FUZZING STATIC TAG";
+
+#[derive(arbitrary::Arbitrary, Debug)]
+pub struct UnblindRespInput {
+    blinded_resp_buf: Vec<u8>,
+}
+
+pub fn unblind_resp(input: UnblindRespInput) {
+    // TODO(victor): Figure out a good way to make these values constant between calls.
+    let static_keypair: wasm::Keypair = wasm::keygen(b"FUZZING STATIC KEYGEN SEED").unwrap();
+    let static_blinded_msg: wasm::BlindedMessage =
+        wasm::blind_msg(b"FUZZING STATIC MSG", b"FUZZING STATIC BLINDING SEED").unwrap();
+
+    wasm::unblind_resp(
+        &static_keypair.public_key(),
+        &static_blinded_msg.blinding_factor(),
+        STATIC_TAG,
+        &input.blinded_resp_buf,
+    )
+    .unwrap_err();
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
+#[cfg(all(feature = "fuzzer", feature = "wasm"))]
+pub mod fuzz;
+
 #[cfg(all(feature = "wasm", feature = "parallel"))]
 compile_error!("feature \"wasm\" and feature \"parrallel\" cannot be used together as WASM does not support threads.");
 

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -1,0 +1,103 @@
+
+use rand_chacha::ChaCha8Rng;
+use rand_core::SeedableRng;
+use bls_crypto::hashers::DirectHasher;
+use threshold_bls::curve::bls12377::PairingCurve as bls377;
+use threshold_bls::group::Element;
+
+use crate::api::{PoprfScheme, PrfScheme, Poly, Scheme, Share, ThresholdScheme};
+use crate::bls12_377::Scalar;
+use crate::hash_to_field::{HashToField, TryAndIncrement};
+//use crate::PoprfError;
+
+type G2Scheme = crate::poprf::G2Scheme<bls377>;
+
+pub fn hash_to_field(data: &[u8]) {
+
+    let domain = b"H2FFUZZ";
+    let hasher = TryAndIncrement::<_, Scalar>::new(&DirectHasher);
+    let hash = hasher.hash_to_field(domain, data).unwrap();
+    assert!(hash != Scalar::one());
+}
+
+// This struct exists to make it easy for the fuzzer to know what sort of 
+// inputs to provide. We allow the fuzzer to seed the RNG, which is 
+// deterministic anyway (we only seed it to avoid code changes), 
+// and supply the message and tag.
+#[derive(arbitrary::Arbitrary, Debug)]
+pub struct PoprfFuzzInput {
+    msg : [char; 16],
+    tag : [char; 16],
+    seed: [u8;32],
+    terms: u8,
+}
+
+pub fn poprfscheme(input: PoprfFuzzInput) {
+    //let mut rng = rand::thread_rng();
+    let mut rng = ChaCha8Rng::from_seed(input.seed);
+    let msg : String = input.msg.iter().collect();
+    let tag : String = input.tag.iter().collect();
+
+    let t : usize = (input.terms % 27) as usize + 3;
+    let private = Poly::<<G2Scheme as Scheme>::Private>::new_from(t - 1, &mut rng);
+    let public = private.commit::<<G2Scheme as Scheme>::Public>();
+    let public_key = public.public_key();
+    let (token, blindmsg) = G2Scheme::blind_msg(msg.as_bytes(), &mut rng).unwrap();
+    let mut partial_resps = Vec::<<G2Scheme as PoprfScheme>::BlindPartialResp>::new();
+    for i in 1..t + 1 {
+        let eval = private.eval(i.try_into().unwrap());
+        let partial_key: Share<<G2Scheme as Scheme>::Private> = Share {
+            private: eval.value,
+            index: eval.index,
+        };
+            let partial_resp =
+                G2Scheme::blind_partial_eval(&partial_key, tag.as_bytes(), &blindmsg).unwrap();
+            partial_resps.push(partial_resp);
+        }
+    let blind_resp = G2Scheme::blind_aggregate(t, &partial_resps[..]).unwrap();
+    let agg_result =
+        G2Scheme::unblind_resp(public_key, &token, tag.as_bytes(), &blind_resp).unwrap();
+
+    // Poly.get(0) returns the constant term, which is the aggregated private key.
+    let agg_key = private.get(0);
+    let result = G2Scheme::eval(&agg_key, tag.as_bytes(), msg.as_bytes()).unwrap();
+    assert_eq!(agg_result, result);
+}
+// This struct exists to make it easy for the fuzzer to know what sort of 
+// inputs to provide. We allow the fuzzer to seed the RNG, which is 
+// deterministic anyway (we only seed it to avoid code changes), 
+// and supply the message and tag.
+#[derive(arbitrary::Arbitrary, Debug)]
+pub struct PartialUnblindFuzzInput {
+    msg : [char; 16],
+    tag : [char; 16],
+    seed: [u8;32],
+    terms: u8,
+    index: u8,
+}
+
+pub fn partialunblind(input: PartialUnblindFuzzInput) {
+    //let mut rng = rand::thread_rng();
+
+    let mut rng = ChaCha8Rng::from_seed(input.seed);
+    let msg : String = input.msg.iter().collect();
+    let tag : String = input.tag.iter().collect();
+
+    let t : usize = (input.terms % 27) as usize + 3;
+    let index : u32 = input.index as u32 % t as u32;
+    let private = Poly::<<G2Scheme as Scheme>::Private>::new_from(t - 1, &mut rng);
+    let public = private.commit::<<G2Scheme as Scheme>::Public>();
+    let (token, blindmsg) = G2Scheme::blind_msg(msg.as_bytes(), &mut rng).unwrap();
+    let private_key = Share {
+        private: private.eval(index).value,
+        index,
+    };
+    let blind_partial_resp =
+        G2Scheme::blind_partial_eval(&private_key, tag.as_bytes(), &blindmsg).unwrap();
+    let blind_result =
+        G2Scheme::unblind_partial_resp(&public, &token, tag.as_bytes(), &blind_partial_resp)
+            .unwrap();
+    let result = G2Scheme::partial_eval(&private_key, tag.as_bytes(), msg.as_bytes()).unwrap();
+    assert_eq!(&blind_result, &result);
+}
+

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -1,10 +1,10 @@
+use bls_crypto::hashers::DirectHasher;
 use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
-use bls_crypto::hashers::DirectHasher;
 use threshold_bls::curve::bls12377::PairingCurve as bls377;
 use threshold_bls::group::Element;
 
-use crate::api::{PoprfScheme, PrfScheme, Poly, Scheme, Share, ThresholdScheme};
+use crate::api::{Poly, PoprfScheme, PrfScheme, Scheme, Share, ThresholdScheme};
 use crate::bls12_377::Scalar;
 use crate::hash_to_field::{HashToField, TryAndIncrement};
 //use crate::PoprfError;
@@ -19,14 +19,14 @@ pub fn hash_to_field(data: &[u8]) {
     assert!(hash != Scalar::zero());
 }
 
-// This struct exists to make it easy for the fuzzer to know what sort of 
-// inputs to provide. We allow the fuzzer to seed the RNG, which is 
-// deterministic anyway (we only seed it to avoid code changes), 
+// This struct exists to make it easy for the fuzzer to know what sort of
+// inputs to provide. We allow the fuzzer to seed the RNG, which is
+// deterministic anyway (we only seed it to avoid code changes),
 // and supply the message and tag.
 #[derive(arbitrary::Arbitrary, Debug)]
 pub struct PoprfFuzzInput {
-    msg : Vec<u8>,
-    tag : Vec<u8>,
+    msg: Vec<u8>,
+    tag: Vec<u8>,
     seed: [u8; 32],
     terms: u8,
 }
@@ -35,7 +35,7 @@ pub fn poprfscheme(input: PoprfFuzzInput) {
     //let mut rng = rand::thread_rng();
     let mut rng = ChaCha8Rng::from_seed(input.seed);
 
-    let t : usize = (input.terms % 27) as usize + 3;
+    let t: usize = (input.terms % 27) as usize + 3;
     let private = Poly::<<G2Scheme as Scheme>::Private>::new_from(t - 1, &mut rng);
     let public = private.commit::<<G2Scheme as Scheme>::Public>();
     let public_key = public.public_key();
@@ -48,14 +48,13 @@ pub fn poprfscheme(input: PoprfFuzzInput) {
             private: eval.value,
             index: eval.index,
         };
-            let partial_resp =
-                G2Scheme::blind_partial_eval(&partial_key, &input.tag, &blindmsg).unwrap();
-            partial_resps.push(partial_resp);
-        }
+        let partial_resp =
+            G2Scheme::blind_partial_eval(&partial_key, &input.tag, &blindmsg).unwrap();
+        partial_resps.push(partial_resp);
+    }
 
     let blind_resp = G2Scheme::blind_aggregate(t, &partial_resps[..]).unwrap();
-    let agg_result =
-        G2Scheme::unblind_resp(public_key, &token, &input.tag, &blind_resp).unwrap();
+    let agg_result = G2Scheme::unblind_resp(public_key, &token, &input.tag, &blind_resp).unwrap();
 
     // Poly.get(0) returns the constant term, which is the aggregated private key.
     let agg_key = private.get(0);
@@ -63,14 +62,14 @@ pub fn poprfscheme(input: PoprfFuzzInput) {
     assert_eq!(agg_result, result);
 }
 
-// This struct exists to make it easy for the fuzzer to know what sort of 
-// inputs to provide. We allow the fuzzer to seed the RNG, which is 
-// deterministic anyway (we only seed it to avoid code changes), 
+// This struct exists to make it easy for the fuzzer to know what sort of
+// inputs to provide. We allow the fuzzer to seed the RNG, which is
+// deterministic anyway (we only seed it to avoid code changes),
 // and supply the message and tag.
 #[derive(arbitrary::Arbitrary, Debug)]
 pub struct PartialUnblindFuzzInput {
-    msg : Vec<u8>,
-    tag : Vec<u8>,
+    msg: Vec<u8>,
+    tag: Vec<u8>,
     seed: [u8; 32],
     terms: u8,
     index: u8,
@@ -81,8 +80,8 @@ pub fn partialunblind(input: PartialUnblindFuzzInput) {
 
     let mut rng = ChaCha8Rng::from_seed(input.seed);
 
-    let t : usize = (input.terms % 27) as usize + 3;
-    let index : u32 = input.index as u32 % t as u32;
+    let t: usize = (input.terms % 27) as usize + 3;
+    let index: u32 = input.index as u32 % t as u32;
     let private = Poly::<<G2Scheme as Scheme>::Private>::new_from(t - 1, &mut rng);
     let public = private.commit::<<G2Scheme as Scheme>::Public>();
     let (token, blindmsg) = G2Scheme::blind_msg(&input.msg, &mut rng).unwrap();
@@ -93,8 +92,7 @@ pub fn partialunblind(input: PartialUnblindFuzzInput) {
     let blind_partial_resp =
         G2Scheme::blind_partial_eval(&private_key, &input.tag, &blindmsg).unwrap();
     let blind_result =
-        G2Scheme::unblind_partial_resp(&public, &token, &input.tag, &blind_partial_resp)
-            .unwrap();
+        G2Scheme::unblind_partial_resp(&public, &token, &input.tag, &blind_partial_resp).unwrap();
     let result = G2Scheme::partial_eval(&private_key, &input.tag, &input.msg).unwrap();
     assert_eq!(&blind_result, &result);
 }

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -1,4 +1,3 @@
-
 use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
 use bls_crypto::hashers::DirectHasher;
@@ -13,11 +12,11 @@ use crate::hash_to_field::{HashToField, TryAndIncrement};
 type G2Scheme = crate::poprf::G2Scheme<bls377>;
 
 pub fn hash_to_field(data: &[u8]) {
-
     let domain = b"H2FFUZZ";
     let hasher = TryAndIncrement::<_, Scalar>::new(&DirectHasher);
     let hash = hasher.hash_to_field(domain, data).unwrap();
     assert!(hash != Scalar::one());
+    assert!(hash != Scalar::zero());
 }
 
 // This struct exists to make it easy for the fuzzer to know what sort of 
@@ -26,24 +25,23 @@ pub fn hash_to_field(data: &[u8]) {
 // and supply the message and tag.
 #[derive(arbitrary::Arbitrary, Debug)]
 pub struct PoprfFuzzInput {
-    msg : [char; 16],
-    tag : [char; 16],
-    seed: [u8;32],
+    msg : Vec<u8>,
+    tag : Vec<u8>,
+    seed: [u8; 32],
     terms: u8,
 }
 
 pub fn poprfscheme(input: PoprfFuzzInput) {
     //let mut rng = rand::thread_rng();
     let mut rng = ChaCha8Rng::from_seed(input.seed);
-    let msg : String = input.msg.iter().collect();
-    let tag : String = input.tag.iter().collect();
 
     let t : usize = (input.terms % 27) as usize + 3;
     let private = Poly::<<G2Scheme as Scheme>::Private>::new_from(t - 1, &mut rng);
     let public = private.commit::<<G2Scheme as Scheme>::Public>();
     let public_key = public.public_key();
-    let (token, blindmsg) = G2Scheme::blind_msg(msg.as_bytes(), &mut rng).unwrap();
+    let (token, blindmsg) = G2Scheme::blind_msg(&input.msg, &mut rng).unwrap();
     let mut partial_resps = Vec::<<G2Scheme as PoprfScheme>::BlindPartialResp>::new();
+
     for i in 1..t + 1 {
         let eval = private.eval(i.try_into().unwrap());
         let partial_key: Share<<G2Scheme as Scheme>::Private> = Share {
@@ -51,27 +49,29 @@ pub fn poprfscheme(input: PoprfFuzzInput) {
             index: eval.index,
         };
             let partial_resp =
-                G2Scheme::blind_partial_eval(&partial_key, tag.as_bytes(), &blindmsg).unwrap();
+                G2Scheme::blind_partial_eval(&partial_key, &input.tag, &blindmsg).unwrap();
             partial_resps.push(partial_resp);
         }
+
     let blind_resp = G2Scheme::blind_aggregate(t, &partial_resps[..]).unwrap();
     let agg_result =
-        G2Scheme::unblind_resp(public_key, &token, tag.as_bytes(), &blind_resp).unwrap();
+        G2Scheme::unblind_resp(public_key, &token, &input.tag, &blind_resp).unwrap();
 
     // Poly.get(0) returns the constant term, which is the aggregated private key.
     let agg_key = private.get(0);
-    let result = G2Scheme::eval(&agg_key, tag.as_bytes(), msg.as_bytes()).unwrap();
+    let result = G2Scheme::eval(&agg_key, &input.tag, &input.msg).unwrap();
     assert_eq!(agg_result, result);
 }
+
 // This struct exists to make it easy for the fuzzer to know what sort of 
 // inputs to provide. We allow the fuzzer to seed the RNG, which is 
 // deterministic anyway (we only seed it to avoid code changes), 
 // and supply the message and tag.
 #[derive(arbitrary::Arbitrary, Debug)]
 pub struct PartialUnblindFuzzInput {
-    msg : [char; 16],
-    tag : [char; 16],
-    seed: [u8;32],
+    msg : Vec<u8>,
+    tag : Vec<u8>,
+    seed: [u8; 32],
     terms: u8,
     index: u8,
 }
@@ -80,24 +80,21 @@ pub fn partialunblind(input: PartialUnblindFuzzInput) {
     //let mut rng = rand::thread_rng();
 
     let mut rng = ChaCha8Rng::from_seed(input.seed);
-    let msg : String = input.msg.iter().collect();
-    let tag : String = input.tag.iter().collect();
 
     let t : usize = (input.terms % 27) as usize + 3;
     let index : u32 = input.index as u32 % t as u32;
     let private = Poly::<<G2Scheme as Scheme>::Private>::new_from(t - 1, &mut rng);
     let public = private.commit::<<G2Scheme as Scheme>::Public>();
-    let (token, blindmsg) = G2Scheme::blind_msg(msg.as_bytes(), &mut rng).unwrap();
+    let (token, blindmsg) = G2Scheme::blind_msg(&input.msg, &mut rng).unwrap();
     let private_key = Share {
         private: private.eval(index).value,
         index,
     };
     let blind_partial_resp =
-        G2Scheme::blind_partial_eval(&private_key, tag.as_bytes(), &blindmsg).unwrap();
+        G2Scheme::blind_partial_eval(&private_key, &input.tag, &blindmsg).unwrap();
     let blind_result =
-        G2Scheme::unblind_partial_resp(&public, &token, tag.as_bytes(), &blind_partial_resp)
+        G2Scheme::unblind_partial_resp(&public, &token, &input.tag, &blind_partial_resp)
             .unwrap();
-    let result = G2Scheme::partial_eval(&private_key, tag.as_bytes(), msg.as_bytes()).unwrap();
+    let result = G2Scheme::partial_eval(&private_key, &input.tag, &input.msg).unwrap();
     assert_eq!(&blind_result, &result);
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ mod poprf;
 mod poprfscheme;
 use thiserror::Error;
 
+#[cfg(feature="fuzzer")]
+pub mod fuzz;
+
 #[derive(Debug, Error)]
 pub enum PoprfError {
     #[error("could not hash to curve")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod poprf;
 mod poprfscheme;
 use thiserror::Error;
 
-#[cfg(feature="fuzzer")]
+#[cfg(feature = "fuzzer")]
 pub mod fuzz;
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
This PR adds cargo fuzz support to celo-poprf and adds
four fuzzing targets. Cargo-fuzz uses libFuzzer and requires
a nightly compiler. Each fuzz target is assembled as a
shared library. The fuzzer accepts a [u8] slice as mutable
input, or if specific structure is desired, it can take
any struct that derives from Arbitrary (and Debug).
As such, we provide input types.

In order to not modify the visibility of the source crate
we add a 'fuzzer' feature which is not enabled by default.
When enabled (it is specified as a dependent feature in the
fuzz crate) the fuzz module exposes some modified unit tests,
that take fuzzer supplied input to unit test features.
